### PR TITLE
FIX : Product list in setup.php in new Module

### DIFF
--- a/htdocs/modulebuilder/template/admin/setup.php
+++ b/htdocs/modulebuilder/template/admin/setup.php
@@ -55,6 +55,8 @@ global $langs, $user;
 // Libraries
 require_once DOL_DOCUMENT_ROOT."/core/lib/admin.lib.php";
 require_once '../lib/mymodule.lib.php';
+require_once DOL_DOCUMENT_ROOT.'/product/class/product.class.php';
+
 //require_once "../class/myclass.class.php";
 
 // Translations


### PR DESCRIPTION

Environment Version

16.0.3
Environment OS

Mac OS 13.0
Environment Web server

Apache 2.4.46
Environment PHP

PHP 7.4.21
Environment Database

MySQL 5.7.34
Environment URL(s)

setup.php
Expected and actual behavior

There is also another issue found with a totally new module being created in the setup.php page.

See attached screenshot.
Steps to reproduce the behavior

Create a new module using the module builder.
Enable new module.
Navigate to setup page for new module.